### PR TITLE
Ability to run project with Docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,11 @@
 FROM chrischoy/minkowski_engine:latest
 
-WORKDIR /root
+WORKDIR /app
 
-COPY ./requirements.txt /root
+COPY ./requirements.txt /app
 
 RUN pip install --no-cache-dir -r requirements.txt && pip install --no-index torch-scatter -f https://pytorch-geometric.com/whl/torch-1.12.0+cu113.html
 
-COPY . /root
+COPY . .
 
 CMD [ "bash" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,11 @@
+FROM chrischoy/minkowski_engine:latest
+
+WORKDIR /root
+
+COPY ./requirements.txt /root
+
+RUN pip install --no-cache-dir -r requirements.txt && pip install --no-index torch-scatter -f https://pytorch-geometric.com/whl/torch-1.12.0+cu113.html
+
+COPY . /root
+
+CMD [ "bash" ]

--- a/README.md
+++ b/README.md
@@ -15,9 +15,13 @@ The repository currently contains pretrained models and datasets for the experim
 
 
 
-## Installation & Data Preparation
+## Installation
 
-1. **Anaconda environment installations for training & testing**
+There are two methods of installing and running the project:
+- Anaconda installation
+- Docker container
+
+### Anaconda environment installations for training & testing
 
 ```
 conda create -n gca python=3.8
@@ -45,10 +49,26 @@ pip install --no-index torch-scatter -f https://pytorch-geometric.com/whl/torch-
 ```
 The repo was tested with NVIDIA 2080ti GPU (11GB). Note that MinkowskiEngine might be difficult to install, please see the issue of the MinkowskiEngine or this repo for help.
 
+### Docker container for training & testing
 
+The repo includes a Docker file with the necessary image and dependancies specified. Make sure you have docker installed and running beforehand.
 
+You can create an image from the dockerfile and then run a container directly, then execute training and testing commands from an attached shell. You can even modify the final layer of the Dockerfile as you see fit, make sure not to tamper with the dependancy layers however. 
 
-2. **Data preparation and Pretrained Models**
+Sample commands to build a docker image and run the docker container are as follows:
+
+```
+# To build the image
+docker build -t gca:train_test .
+
+# To run container
+docker run -it --gpus all gca:train_test
+```
+
+It is important to include the `--gpus` tag, otherwise the container will not utilise the system GPU for training and testing.
+
+## Data Preparation and Pretrained Models
+
 
 [Link](https://drive.google.com/drive/folders/1DID47BZBkPHKPhpPgpmZgM7GBoutqlPa?usp=sharing) contains the datasets (sdf & preprocessed sparse voxel embedding for ShapeNet, ShapnetNet scene) and pretrained models (GCA, cGCA, cGCA w/ cond.). Place the files with directory as below. This link contains all the data except for conv_onet (input point cloud of ShapeNet scene dataset), which can be downloaded from [here](https://github.com/autonomousvision/convolutional_occupancy_networks#synthetic-indoor-scene-dataset) and unzipped/renamed as `conv_onet` from `synthetic_room_dataset.zip`. All directories not specified as downloadable from conv_onet repo can be obtained from our google drive. Note that we call the Shapenet Scene datasets as synthetic as abbreviation.  
 


### PR DESCRIPTION
# Preface

I got the motivation to add a way to run this amazing project with docker when I was not able to get the installation right using anaconda. I figured including docker as a method to run the project would make it easier to understand, run and tinker with this repository and its contents. 

Installing [Minkowski Engine](https://github.com/NVIDIA/MinkowskiEngine) was the biggest hurdle. After searching the web for a while, i came across [this blog](https://blog.csdn.net/weixin_44330874/article/details/129678041) which included through details to run Minkowski Engine with docker as well as anaconda and local installations. I do know who the original creator is of this blog, since I had to translate the site to understand it. 

Using the image specified in the blog, I was able to create a Dockefile that could run the training and testing commands. It also includes proper installation of pytorch-scatter library.

# Changes made
- Dockefile created using the [image](https://hub.docker.com/r/chrischoy/minkowski_engine?uuid=62E92FD3-4B9A-45A3-819A-ACDB6DCC5163) specified in the blog and correct dependencies to run the project
- Updated the README.md with the correct steps to build and run the docker container

# Conclusion

While it is not a significant change, I think adding this minor functionality could allow people interested in this research to be up to speed with it much faster and not have to worry too much about dependencies. 